### PR TITLE
Package upgrades

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@arcgis/core": "4.29.0",
-        "@esri/calcite-components": "2.13.2",
+        "@esri/calcite-components": "2.8.5",
         "@usepa-ngst/calcite-components": "^0.0.1",
         "@usepa-ngst/utilities": "^0.0.4",
         "page": "^1.11.6"
@@ -414,23 +414,20 @@
       "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "node_modules/@esri/calcite-components": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.13.2.tgz",
-      "integrity": "sha512-90v4H8zs2wEzUXQGmZ+joHhP7ulFUHmQjDlIwXylJiDvoChhnEm38iv7eeG+X8im06biIHEDGRB8LLszlQQ7jw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.8.5.tgz",
+      "integrity": "sha512-QMZQ38utrt02o6rnBVTLKfAha2Kjyt1JPf+lIZVfO9RHmBofrHsMuRXoY0WCE5Ug2SeDpvlChH4KA6nSjdXf8A==",
       "dependencies": {
-        "@esri/calcite-ui-icons": "3.32.0",
-        "@floating-ui/dom": "1.6.11",
-        "@stencil/core": "4.20.0",
+        "@floating-ui/dom": "1.6.3",
+        "@stencil/core": "4.17.1",
         "@types/color": "3.0.6",
-        "@types/sortablejs": "1.15.8",
         "color": "4.2.3",
-        "composed-offset-position": "0.0.6",
-        "dayjs": "1.11.13",
-        "focus-trap": "7.6.0",
-        "interactjs": "1.10.27",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.10",
+        "focus-trap": "7.5.4",
         "lodash-es": "4.17.21",
-        "sortablejs": "1.15.3",
-        "timezone-groups": "0.10.2",
+        "sortablejs": "1.15.1",
+        "timezone-groups": "0.8.0",
         "type-fest": "4.18.2"
       }
     },
@@ -442,13 +439,10 @@
         "@types/color-convert": "*"
       }
     },
-    "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.32.0.tgz",
-      "integrity": "sha512-2UEddEeSnpXVWp/uNrgym3mrb8lZ5+vXFbtmvXv5NiE32nQGw2MFZD52L5Z+FsxqHJ9vVrtl/X6pTIgkd0c8jA==",
-      "bin": {
-        "spriter": "bin/spriter.js"
-      }
+    "node_modules/@esri/calcite-components/node_modules/sortablejs": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
+      "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
     },
     "node_modules/@floating-ui/core": {
       "version": "1.6.8",
@@ -459,23 +453,18 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
-      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
-    },
-    "node_modules/@interactjs/types": {
-      "version": "1.10.27",
-      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
-      "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
@@ -561,9 +550,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz",
-      "integrity": "sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.17.1.tgz",
+      "integrity": "sha512-nlARe1QtK5abnCG8kPQKJMWiELg39vKabvf3ebm6YEhQA35CgrxC1pVYTsYq3yktJKoY+k+VzGRnATLKyaLbvA==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -629,11 +618,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
-    },
-    "node_modules/@types/sortablejs": {
-      "version": "1.15.8",
-      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
-      "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg=="
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -920,12 +904,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/composed-offset-position": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
-      "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
-      "peerDependencies": {
-        "@floating-ui/utils": "^0.2.5"
-      }
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
     },
     "node_modules/css-tree": {
       "version": "2.3.1",
@@ -946,9 +927,9 @@
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1023,9 +1004,9 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -1042,14 +1023,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/interactjs": {
-      "version": "1.10.27",
-      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
-      "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
-      "dependencies": {
-        "@interactjs/types": "1.10.27"
       }
     },
     "node_modules/is-arrayish": {
@@ -1311,11 +1284,11 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/timezone-groups": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.10.2.tgz",
-      "integrity": "sha512-01G9JdlIybA9Njp0wJcGenXKWAw+woWbv6W/oMexWyPs7Nr/S2p2n1NRrMHbHaFzdf+PNNStQp1WILdnAGjYXQ==",
-      "engines": {
-        "node": ">=18.12.0"
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
+      "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA==",
+      "bin": {
+        "timezone-groups": "dist/cli.cjs"
       }
     },
     "node_modules/type-fest": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@arcgis/core": "4.29.0",
-    "@esri/calcite-components": "2.13.2",
+    "@esri/calcite-components": "2.8.5",
     "@usepa-ngst/calcite-components": "^0.0.1",
     "@usepa-ngst/utilities": "^0.0.4",
     "page": "^1.11.6"


### PR DESCRIPTION
This should address npm vulnerabilities for svelte, rollup, vite. And upgrade outdated sveltejs/vite-plugin-svelte. It doesn't address the issue for path-to-regexp, which is a dependency for page. Doesn't look like page is actively in development anymore, so not sure if upgrading path-to-regexp would break page.