### PR TITLE
Feature/filter data catalog by geography

### DIFF
--- a/client/src/components/ClimateChangeViewer/Bookmark.svelte
+++ b/client/src/components/ClimateChangeViewer/Bookmark.svelte
@@ -1,114 +1,45 @@
 <script>
+    //Rethinking this component...
+    //Could be more flexible if the action buttons were each blocks
+    //and names and extents were passed in as props.
+    //Would need a click handler function that looks at active action and toggles 
+    //Needs to pass a filter prop to data catalog
+    import { geography } from "src/store.ts";
     import Extent from "@arcgis/core/geometry/Extent";
 
     export let view;
 
-    const _onHawaiiClick = (view) => {
-        let extent = new Extent({
-            xmax: -17232996.3537,
-            xmin: -17838620.5975,
-            ymax: 2539458.2165,
-            ymin: 2144428.1256,
-            spatialReference: { wkid: 102100 },
-        });
+    let bookmarks = [
+        { name: "CONUS", text: "Continental US", extentObj: {xmax: -5347672, xmin: -15914327, ymax: 7733573, ymin: 1853426}}, 
+        { name: "Hawaii", text: "Hawaii", extentObj: { xmax: -17232996.3537, xmin: -17838620.5975, ymax: 2539458.2165, ymin: 2144428.1256}},
+        { name: "Alaska", text: "Alaska", extentObj: { xmax: -15876210.0, xmin: -19061453.32, ymax: 12511315.0, ymin: 6923265.0}},
+        { name: "Guam", text: "Guam", extentObj: { xmax: 16446175.757969558, xmin: 16004237.379520258, ymax: 2301068.6854367177, ymin: 1503028.389935526}},
+        { name: "Prvi", text: "Puerto Rico & Virgin Islands", extentObj: { xmax: -7187363.955800, xmin: -7564321.223000, ymax: 2098168.552400, ymin: 1999395.310000}},
+        { name: "PacIsles", text: "Pacific Islands", extentObj: { xmax: -18844510.286599636, xmin: -19163997.22517633, ymax: -1444391.585028562, ymin: -1774134.0808157807}}
+    ];
+
+    let bookmarkPopupButton;
+
+    const onGeogChange = (bookmark) => {
+        let extent = new Extent({...bookmark.extentObj, spatialReference: { wkid: 102100 }});
         view.goTo(extent).catch(function (error) {
             if (error.name != "AbortError") {
                 console.error(error);
             }
         });
-        document.querySelector('[id="climate-change-popover-button"]').open =
-            false;
+
+        //TODO: only one bookmark can be active at a time
+        // QUESTION: Is there a "none" or "Clear" option? Or just select the same one twice and it "unselects" all?
         document.querySelector('[id="popover-button"]').indicator = true;
-        document.querySelector('[id="climate-filter-hawaii"]').active = true;
+
+        bookmarkPopupButton.open = false;
+        bookmark.element.active = true;
+ 
+        //TODO: put in all stuff that changes this dataList Query Store we are creating that triggers dataList refresh in that comopnent
+        
+        $geography = bookmark.name
+        console.log($geography)
     };
-
-    const _onConusClick = (view) => {
-        let extent = new Extent({
-            xmax: -5347672,
-            xmin: -15914327,
-            ymax: 7733573,
-            ymin: 1853426,
-            spatialReference: { wkid: 102100 },
-        });
-        view.goTo(extent).catch(function (error) {
-            if (error.name != "AbortError") {
-                console.error(error);
-            }
-        });
-        document.querySelector('[id="climate-change-popover-button"]').open =
-            false;
-        document.querySelector('[id="popover-button"]').indicator = true;
-        document.querySelector('[id="climate-filter-conus"]').active = true;
-    };
-
-    const _onAlaskaClick = (view) => {
-        let extent = new Extent({
-            xmax: -15876210.0,
-            xmin: -19061453.32,
-            ymax: 12511315.0,
-            ymin: 6923265.0,
-            spatialReference: { wkid: 102100 },
-        });
-        view.goTo(extent).catch(function (error) {
-            if (error.name != "AbortError") {
-                console.error(error);
-            }
-        });
-        document.querySelector('[id="climate-change-popover-button"]').open =
-            false;
-        document.querySelector('[id="popover-button"]').indicator = true;
-        document.querySelector('[id="climate-filter-alaska"]').active = true;
-    };
-
-    const _onPrViClick = (view) => {
-        let extent = new Extent({
-            xmax: -7187363.955800,
-            xmin: -7564321.223000,
-            ymax: 2098168.552400,
-            ymin: 1999395.310000,
-            spatialReference: { wkid: 102100 },
-        });
-        view.goTo(extent).catch(function (error) {
-            if (error.name != "AbortError") {
-                console.error(error);
-            }
-        });
-        document.querySelector('[id="climate-change-popover-button"]').open =
-            false;
-        document.querySelector('[id="popover-button"]').indicator = true;
-        document.querySelector('[id="climate-filter-prvi"]').active = true;
-        console.log(document.querySelector('[id="climate-filter-action-group"]'));
-    };
-
-    const _onGuamClick = (view) => {
-        let extent = new Extent({
-			xmax: 16446175.757969558,
-			xmin: 16004237.379520258,
-			ymax: 2301068.6854367177,
-			ymin: 1503028.389935526,
-            spatialReference: { wkid: 102100 },
-        });
-        view.goTo(extent).catch(function (error) {
-            if (error.name != "AbortError") {
-                console.error(error);
-            }
-        });
-    }
-
-    const _onPacIslesClick = (view) => {
-        let extent = new Extent({
-			xmax: -18844510.286599636,
-			xmin: -19163997.22517633,
-			ymax: -1444391.585028562,
-			ymin: -1774134.0808157807,
-            spatialReference: { wkid: 102100 },
-        });
-        view.goTo(extent).catch(function (error) {
-            if (error.name != "AbortError") {
-                console.error(error);
-            }
-        });
-    }
 </script>
 
 <calcite-popover
@@ -119,68 +50,27 @@
     label="Filter options"
     reference-element="popover-button"
     id="climate-change-popover-button"
+    bind:this={bookmarkPopupButton}
 >
     <calcite-tooltip>Filter data and zoom to extent</calcite-tooltip>
     <calcite-action-group id="climate-filter-action-group" scale="s">
-        <calcite-action
-            tabindex="0"
-            role="button"
-            id="climate-filter-conus"
-            scale="s"
-            text="Continental US"
-            text-enabled
-            on:click={_onConusClick(view)}
-            on:keypress={_onConusClick(view)}
-        ></calcite-action>
-        <calcite-action
-            tabindex="0"
-            role="button"
-            id="climate-filter-alaska"
-            scale="s"
-            text="Alaska"
-            text-enabled
-            on:click={_onAlaskaClick(view)}
-            on:keypress={_onAlaskaClick(view)}
-        ></calcite-action>
-        <calcite-action
-            tabindex="0"
-            role="button"
-            id="climate-filter-hawaii"
-            scale="s"
-            text="Hawaii"
-            text-enabled
-            on:click={_onHawaiiClick(view)}
-            on:keypress={_onHawaiiClick(view)}
-        ></calcite-action>
-        <calcite-action
-            tabindex="0"
-            role="button"    
-            id="climate-filter-prvi"
-            scale="s"
-            text="Puerto Rico & Virgin Islands"
-            text-enabled
-            on:click={_onPrViClick(view)}
-            on:keypress={_onPrViClick(view)}
-        ></calcite-action>
-        <calcite-action 
-            tabindex="0"
-            role="button"
-            id="climate-filter-guam"
-            scale="s" 
-            text="Guam" 
-            text-enabled
-            on:click={_onGuamClick(view)}
-            on:keypress={_onGuamClick(view)}
-        ></calcite-action>
-        <calcite-action 
-            tabindex="0"
-            role="button"
-            id="climate-filter-pacisles"
-            scale="s" 
-            text="Pacific Islands" 
-            text-enabled
-            on:click={_onPacIslesClick(view)}
-            on:keypress={_onPacIslesClick(view)}
-        ></calcite-action>
+        {#each bookmarks as bm}
+            <calcite-action
+                bind:this={bm.element}
+                label={bm.name}
+                tabindex="0"
+                role="button"
+                scale="s"
+                text={bm.text}
+                text-enabled
+                on:click={()=>onGeogChange(bm)}
+                on:keypress={()=>onGeogChange(bm)}
+            ></calcite-action>
+        {/each}
     </calcite-action-group>
 </calcite-popover>
+
+
+
+
+ 

--- a/client/src/components/ClimateChangeViewer/Bookmark.svelte
+++ b/client/src/components/ClimateChangeViewer/Bookmark.svelte
@@ -4,7 +4,7 @@
     //and names and extents were passed in as props.
     //Would need a click handler function that looks at active action and toggles 
     //Needs to pass a filter prop to data catalog
-    import { geography } from "src/store.ts";
+    import { filteredNationalItems, nationalItems, geography } from "src/store.ts";
     import Extent from "@arcgis/core/geometry/Extent";
 
     export let view;
@@ -36,10 +36,12 @@
         bookmark.element.active = true;
  
         //TODO: put in all stuff that changes this dataList Query Store we are creating that triggers dataList refresh in that comopnent
-        
+       
         $geography = bookmark.name
         console.log($geography)
+        console.log($filteredNationalItems)
     };
+
 </script>
 
 <calcite-popover

--- a/client/src/components/ClimateChangeViewer/Bookmark.svelte
+++ b/client/src/components/ClimateChangeViewer/Bookmark.svelte
@@ -79,6 +79,36 @@
         document.querySelector('[id="climate-filter-prvi"]').active = true;
         console.log(document.querySelector('[id="climate-filter-action-group"]'));
     };
+
+    const _onGuamClick = (view) => {
+        let extent = new Extent({
+			xmax: 16446175.757969558,
+			xmin: 16004237.379520258,
+			ymax: 2301068.6854367177,
+			ymin: 1503028.389935526,
+            spatialReference: { wkid: 102100 },
+        });
+        view.goTo(extent).catch(function (error) {
+            if (error.name != "AbortError") {
+                console.error(error);
+            }
+        });
+    }
+
+    const _onPacIslesClick = (view) => {
+        let extent = new Extent({
+			xmax: -18844510.286599636,
+			xmin: -19163997.22517633,
+			ymax: -1444391.585028562,
+			ymin: -1774134.0808157807,
+            spatialReference: { wkid: 102100 },
+        });
+        view.goTo(extent).catch(function (error) {
+            if (error.name != "AbortError") {
+                console.error(error);
+            }
+        });
+    }
 </script>
 
 <calcite-popover
@@ -132,7 +162,25 @@
             on:click={_onPrViClick(view)}
             on:keypress={_onPrViClick(view)}
         ></calcite-action>
-        <calcite-action scale="s" text="Pacific Islands" text-enabled
+        <calcite-action 
+            tabindex="0"
+            role="button"
+            id="climate-filter-guam"
+            scale="s" 
+            text="Guam" 
+            text-enabled
+            on:click={_onGuamClick(view)}
+            on:keypress={_onGuamClick(view)}
+        ></calcite-action>
+        <calcite-action 
+            tabindex="0"
+            role="button"
+            id="climate-filter-pacisles"
+            scale="s" 
+            text="Pacific Islands" 
+            text-enabled
+            on:click={_onPacIslesClick(view)}
+            on:keypress={_onPacIslesClick(view)}
         ></calcite-action>
     </calcite-action-group>
 </calcite-popover>

--- a/client/src/components/ClimateChangeViewer/Bookmark.svelte
+++ b/client/src/components/ClimateChangeViewer/Bookmark.svelte
@@ -1,10 +1,5 @@
 <script>
-    //Rethinking this component...
-    //Could be more flexible if the action buttons were each blocks
-    //and names and extents were passed in as props.
-    //Would need a click handler function that looks at active action and toggles 
-    //Needs to pass a filter prop to data catalog
-    import { filteredNationalItems, nationalItems, geography } from "src/store.ts";
+    import { filteredNationalItems, geography } from "src/store.ts";
     import Extent from "@arcgis/core/geometry/Extent";
 
     export let view;
@@ -28,8 +23,7 @@
             }
         });
 
-        //TODO: only one bookmark can be active at a time
-        // QUESTION: Is there a "none" or "Clear" option? Or just select the same one twice and it "unselects" all?
+        //TODO: only one bookmark can be active at a time. No "clear" or "none" option. Conus is default.
         document.querySelector('[id="popover-button"]').indicator = true;
 
         bookmarkPopupButton.open = false;
@@ -71,8 +65,3 @@
         {/each}
     </calcite-action-group>
 </calcite-popover>
-
-
-
-
- 

--- a/client/src/components/DataCatalog/CatalogListItem.svelte
+++ b/client/src/components/DataCatalog/CatalogListItem.svelte
@@ -99,7 +99,7 @@
     }
 
 </script>
-
+{#if subtopic.isVisible}
 <calcite-list-item label={subtopic.name} on:calciteListItemSelect={e=>e.stopPropagation()}>
     {#if subtopic.layers.length == 1}
     <calcite-checkbox 
@@ -126,10 +126,12 @@
     {#if subtopic.layers.length > 1}
     <div slot="content-bottom" id="concernFilterDiv">
         {#each subtopic.layers as layer (layer.layerID)}
+        {#if layer.isVisible}
             <calcite-label scale='s' layout="inline">
                 <calcite-checkbox name={layer.name} value={layer.layerID} on:calciteCheckboxChange={subtopicSelected}></calcite-checkbox>
                 {layer.subLayerName}
             </calcite-label>
+        {/if}
         {/each}
     </div>
     {/if}
@@ -248,6 +250,7 @@
             {/each}
         </calcite-chip-group>
 </calcite-list-item>
+{/if}
 
 <style>
     #ea-chip-group {

--- a/client/src/components/DataCatalog/CatalogListItem.svelte
+++ b/client/src/components/DataCatalog/CatalogListItem.svelte
@@ -48,7 +48,6 @@
         } else if ($activeWidget.right !== "layers") {
             // Given the right side panel is open, when Add to map is clicked, 
             // the right side panel remains open and has layer list visible
-            console.log("toggle off of ", $activeWidget.right)
             layerPanel.removeAttribute("hidden");
             layerPanel.removeAttribute("closed");
             document.querySelector(`[data-action-id=${$activeWidget.right}]`).active = false;
@@ -101,7 +100,7 @@
 
 </script>
 
-<calcite-list-item label={subtopic.name}>
+<calcite-list-item label={subtopic.name} on:calciteListItemSelect={e=>e.stopPropagation()}>
     {#if subtopic.layers.length == 1}
     <calcite-checkbox 
         slot="actions-start" 

--- a/client/src/components/DataCatalog/CatalogListItem.svelte
+++ b/client/src/components/DataCatalog/CatalogListItem.svelte
@@ -125,7 +125,7 @@
     </calcite-action>
     {#if subtopic.layers.length > 1}
     <div slot="content-bottom" id="concernFilterDiv">
-        {#each subtopic.layers as layer}
+        {#each subtopic.layers as layer (layer.layerID)}
             <calcite-label scale='s' layout="inline">
                 <calcite-checkbox name={layer.name} value={layer.layerID} on:calciteCheckboxChange={subtopicSelected}></calcite-checkbox>
                 {layer.subLayerName}

--- a/client/src/components/DataCatalog/DataList.svelte
+++ b/client/src/components/DataCatalog/DataList.svelte
@@ -9,7 +9,7 @@
     import "@esri/calcite-components/dist/components/calcite-action-group";
 
     // Import components and store
-    import { catalog, nationalItems } from "src/store.ts";
+    import { catalog, nationalItems, filteredNationalItems } from "src/store.ts";
     import CatalogListItem from "src/components/DataCatalog/CatalogListItem.svelte";
     import CatalogActionBar from "src/components/DataCatalog/CatalogActionBar.svelte";
     import ClimateChangeViewer from "src/components/ClimateChangeViewer/ClimateChangeViewer.svelte";
@@ -60,7 +60,7 @@
             // console.log(`${prop}: ${data[prop].topic}`);
             // apply topic to subtopic params
             let subtopicParams = {
-                select: encodeURIComponent(`{"topic":0,"categoryTab":0,"layers":{"layerID":1,"subLayerName":1,"description":1,"tags":1,"name":1}}`),
+                select: encodeURIComponent(`{"topic":0,"categoryTab":0,"layers":{"layerID":1,"subLayerName":1,"description":1,"areaGeog":1,"name":1}}`),
                 where: encodeURIComponent(`{"topic":"${data[prop].topic}"}`)
             };
             // get subtopic object from api
@@ -202,7 +202,7 @@
                 {#await eaTopics}
                     <p>...loading</p>
                 {:then}
-                    {#each $nationalItems as ea}
+                    {#each $filteredNationalItems as ea}
                     <calcite-list-item
                         class={ea.categoryTab}
                         label={ea.topic}

--- a/client/src/components/DataCatalog/DataList.svelte
+++ b/client/src/components/DataCatalog/DataList.svelte
@@ -18,9 +18,6 @@
     import AddData from "@usepa-ngst/calcite-components/AddData/index.svelte";
     import { getEaData } from "src/shared/utilities.js"
 
-    // Import svelte
-    import { afterUpdate } from "svelte";
-
     export let view;
     export let map;
 
@@ -76,13 +73,12 @@
             resNoComm.sort((a,b) => a.name.localeCompare(b.name));
             // take the result and put into store subtopic object
             $nationalItems[prop].subtopic = resNoComm;
-            //$nationalItems[prop].subtopic = $nationalItems[prop].subtopic.map(sub => ({...sub, isVisible: true}))
         }
         return data
     }
 
     // wait for eaTopics to finish before updating data for catalog UI
-    eaTopics.then((result) => getEaSubtopics(result)).then(() => console.log($nationalItems));
+    eaTopics.then((result) => getEaSubtopics(result));
 
     async function updateListStyle(elem) {
         const shadow = elem.shadowRoot;
@@ -160,7 +156,6 @@
     function listItemExpand() {
         !this.open ? this.setAttribute("open", "") : this.removeAttribute("open")
     }
-
 </script>
 
 <calcite-flow data-panel-id="data-catalog" id="data-catalog" open>

--- a/client/src/components/DataCatalog/DataList.svelte
+++ b/client/src/components/DataCatalog/DataList.svelte
@@ -202,7 +202,7 @@
                 {#await eaTopics}
                     <p>...loading</p>
                 {:then}
-                    {#each $filteredNationalItems as ea}
+                    {#each $filteredNationalItems as ea (ea.topic)}
                     <calcite-list-item
                         class={ea.categoryTab}
                         label={ea.topic}
@@ -215,7 +215,7 @@
                             selection-mode="none"
                         >
                         {#if ea.subtopic}
-                            {#each ea.subtopic as subtopic}
+                            {#each ea.subtopic as subtopic (subtopic.subTopicID)}
                                 <CatalogListItem {subtopic} {view} />
                             {/each}
                         {/if}

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store";
+import { derived, writable } from "svelte/store";
 
 // don't have to call this state; shared between components (App and AppShell)
 export const viewState = writable({
@@ -66,8 +66,10 @@ export function resetSMA(): void {
 };
 
 export const catalog = writable({
-    type: "national"
+    type: "national",
 });
+
+export const geography = writable('')
 
 export const nationalItems = writable([]);
 
@@ -75,4 +77,18 @@ export const searchTerm = writable('');
 
 export const activeWidget = writable({
     right: null
-})
+});
+
+export const filteredNationalItems = derived(
+    [nationalItems, geography], ([$nationalItems, $geography]) => {
+        if (!$geography) {
+            return $nationalItems
+        } if ($geography) {
+            return $nationalItems.map(category => {
+                return {...category, subtopic: category.subtopic.map(subtopic => {
+                    return {...subtopic, layers: subtopic.layers.filter(lyr => lyr.areaGeog.includes($geography))};
+                }).filter(subtopic => subtopic.layers.length > 0)}
+            }).filter(category => category.subtopic.some(subtopic => subtopic.layers.length > 0))    
+        }
+    }
+)

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -71,15 +71,13 @@ export const catalog = writable({
 
 export const geography = writable('')
 
-export const nationalItems = writable([
-]);
+export const nationalItems = writable([]);
 
 export const searchTerm = writable('');
 
 export const activeWidget = writable({
     right: null
 });
-
 
 // If we can rewrite things to call api instead of using store, then this is all unnecessary...
 

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -71,7 +71,8 @@ export const catalog = writable({
 
 export const geography = writable('')
 
-export const nationalItems = writable([]);
+export const nationalItems = writable([
+]);
 
 export const searchTerm = writable('');
 
@@ -79,6 +80,12 @@ export const activeWidget = writable({
     right: null
 });
 
+
+// If we can rewrite things to call api instead of using store, then this is all unnecessary...
+
+// derived store that filters each level of UI data (level1=topic, level2=subtopic, level3=layers) based on geography
+// This works, but re-rendering has the downstream effect of needing to override shadow dom again, which I couldn't figure out how to correct.
+// To recreate the issue, filter to Hawaii, then filter to CONUS...the calcite-list-items aren't height: 19px when they re-render.
 export const filteredNationalItems = derived(
     [nationalItems, geography], ([$nationalItems, $geography]) => {
         if (!$geography) {
@@ -92,3 +99,40 @@ export const filteredNationalItems = derived(
         }
     }
 )
+
+// This is the in-between code from filtering (above) to using an isVisible prop in each level of UI data (level1=topic, level2=subtopic, level3=layers)
+// export const filteredNationalItems = derived(
+//     [nationalItems, geography], ([$nationalItems, $geography]) => {
+//         if (!$geography) {
+//             return $nationalItems
+//         } if ($geography) {
+//             return $nationalItems.map(category => {
+//                 return {...category, subtopic: category.subtopic.map(subtopic => {
+//                     return {...subtopic, layers: subtopic.layers.map(lyr => {
+//                         return {...lyr, ...((lyr.areaGeog.includes($geography)) ? {isVisible: true} : {isVisible: false})}
+//                     })}
+//                 })}
+//             })    
+//         }
+//     }
+// )
+
+// Almost got this working, but need to set top level object.isVisible to false if there aren't some subtopic.isVisible
+// This was trying to get around re-rendering components that drop the shadow dom overriding css in DataList.svelte
+// export const filteredNationalItems = derived(
+//     [nationalItems, geography], ([$nationalItems, $geography]) => {
+//         if (!$geography) {
+//             return $nationalItems
+//         } if ($geography) {
+//             return $nationalItems.map(category => {
+//                 return {...category, subtopic: category.subtopic.map(subtopic => {
+//                     const lyrObj = subtopic.layers.map(lyr => {
+//                         return {...lyr, ...((lyr.areaGeog.includes($geography)) ? {isVisible: true} : {isVisible: false})}
+//                     });
+//                     const isSubVis = lyrObj.some(lyr => lyr.isVisible);
+//                     return {...subtopic, lyr: lyrObj, isVisible: isSubVis}
+//                 })}
+//             })    
+//         }
+//     }
+// )


### PR DESCRIPTION
Made some progress, but not sure its the right path forward for the filter method.

- filter the data catalog list (eaScale: CONUS, Hawaii, Alaska, etc)
   - If we can rewrite things to call api instead of using store, then this is all unnecessary for filtering geography...
   - Created a derived store that filters each level of UI data (level1=topic, level2=subtopic, level3=layers) based on geography
   - It works, but re-rendering has the downstream effect of needing to override shadow dom again, which I couldn't figure out how to correct.
   - To recreate the issue, filter to Hawaii, then filter to CONUS...the calcite-list-items aren't height: 19px when they re-render.
   - Also tried added a prop isVisible to each level of UI data (commented out the code in store.ts) as an alternative to filtering, but its missing code to set top level object .isVisible to false if there aren't some subtopic.isVisible
- add extent definition for Pacific Islands and Guam
- refactor, so code is not specific to the climate data viewer