### PR TITLE
popup and popover behavior edits.

### DIFF
--- a/client/src/components/AppShell.svelte
+++ b/client/src/components/AppShell.svelte
@@ -173,6 +173,7 @@
   function layerListAction(e) {
     const id = e.detail.action.id;
     if (id === "trash") {
+      view.popup.close();
       const title = e.detail.item.layer.title;
       // remove tile layer and feature layer with same title
       const removals = e.detail.item.view.map.allLayers.filter(function(layer) {

--- a/client/src/components/TimeSeriesViewer/Bookmark.svelte
+++ b/client/src/components/TimeSeriesViewer/Bookmark.svelte
@@ -33,6 +33,7 @@
 
 <calcite-popover
     placement="trailing-start"
+    auto-close
     overlay-positioning="fixed"
     scale="s"
     heading="Geography"

--- a/client/src/shared/utilities.js
+++ b/client/src/shared/utilities.js
@@ -155,11 +155,12 @@ export function removeLayer(lyrName, view) {
     const foundLyr = view.map.allLayers.filter(function(layer) {
         return layer.title === lyrName;
     });
-    if (foundLyr) {
+    if (foundLyr.length > 0) {
+        view.popup.close();
         foundLyr.forEach((lyr) => {
             view.map.remove(lyr);
-        }) 
-    };         
+        });
+    }
 };
 
 export function addFeatureLayer(lObj, view) {


### PR DESCRIPTION
Auto-close the geography popover. When layer is removed from map (via data catalogue or active layer list), close the popup.